### PR TITLE
Make Flow spinner distinctive

### DIFF
--- a/lib/flowStatus.js
+++ b/lib/flowStatus.js
@@ -57,7 +57,7 @@ export class Status {
   render() {
     if (this.isBusy()) {
       this.statusBarItem.show();
-      this.statusBarItem.text = Status.spin();
+      this.statusBarItem.text = `Flow: ${Status.spin()}`;
     } else {
       this.statusBarItem.hide();
       this.statusBarItem.text = ``


### PR DESCRIPTION
When having multiple plugins that use spinners, it's impossible to tell if the user sees a Flow plugin spinner or not.